### PR TITLE
为SQLiteStorage加入迭代器和items方法，以便于在内部/外部以更多更好的姿♂势访问

### DIFF
--- a/werobot/session/sqlitestorage.py
+++ b/werobot/session/sqlitestorage.py
@@ -30,6 +30,20 @@ class SQLiteStorage(SessionStorage):
         self.db.text_factory = str
         self.db.execute(__CREATE_TABLE_SQL__)
 
+    def __iter__(self):
+        session_json = self.db.execute(
+            "SELECT id FROM WeRoBot;"
+        )
+        for id in session_json:
+            yield id[0]
+
+    def items(self):
+        session_json = self.db.execute(
+            "SELECT id,value FROM WeRoBot;"
+        )
+        for id, value in session_json:
+            yield id, json_loads(value)
+
     def get(self, id):
         session_json = self.db.execute(
             "SELECT value FROM WeRoBot WHERE id=? LIMIT 1;", (id,)

--- a/werobot/session/sqlitestorage.py
+++ b/werobot/session/sqlitestorage.py
@@ -34,15 +34,15 @@ class SQLiteStorage(SessionStorage):
         session_json = self.db.execute(
             "SELECT id FROM WeRoBot;"
         )
-        for id in session_json:
-            yield id[0]
+        for _id in session_json:
+            yield _id[0]
 
     def items(self):
         session_json = self.db.execute(
             "SELECT id,value FROM WeRoBot;"
         )
-        for id, value in session_json:
-            yield id, json_loads(value)
+        for _id, value in session_json:
+            yield _id, json_loads(value)
 
     def get(self, id):
         session_json = self.db.execute(


### PR DESCRIPTION
为SQLiteStorage加入__iter__和items方法，现在可以在session_storage在使用SQLiteStorage时从外部通过
```
for x in robot.session_storage:
    print(x)
```
来访问所有id，以及通过
```
for x, y in robot.session_storage.items():
    print(x,y)
```
来遍历所有session
